### PR TITLE
refactor: ignore story files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "lib": ["ESNext", "DOM"]
   },
   "include": ["src"],
+  "exclude": ["*.story.ts", "*.story.tsx"],
   "typeAcquisition": {
     "enable": true
   }


### PR DESCRIPTION
Ignored `.story.*` files because they don't accomplish anything else than previewing components.