### PR TITLE
fix: scope of `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^4.3.2"
   },
   "lint-staged": {
-    "src/**/**/*.{ts, tsx}": [
+    "src/**/*.{ts, tsx}": [
       "yarn lint:fix",
       "yarn prettify",
       "yarn test",


### PR DESCRIPTION
Fixed scope of `lint-staged` for it to find files.