### PR TITLE
fix: expected ip length

### DIFF
--- a/tests/useGeolocation.test.ts
+++ b/tests/useGeolocation.test.ts
@@ -10,6 +10,6 @@ describe("getGeolocation", () => {
   it("returns an ip", async () => {
     const geolocation = await getGeolocation();
 
-    expect(geolocation.length).toBeGreaterThanOrEqual(14);
+    expect(geolocation.length).toBeGreaterThanOrEqual(13);
   });
 });


### PR DESCRIPTION
Changed expected IP length to `13` because it's the minimum length for an IP.