### PR TITLE
refactor: move lint staged config to another file

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,8 @@
+{
+  "src/**/*.{ts,tsx}": [
+    "yarn lint:fix",
+    "yarn prettify",
+    "yarn test:related",
+    "git add . -A"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -70,13 +70,5 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "typescript": "^4.3.2"
-  },
-  "lint-staged": {
-    "src/**/*.{ts, tsx}": [
-      "yarn lint:fix",
-      "yarn prettify",
-      "yarn test:related",
-      "git add . -A"
-    ]
   }
 }


### PR DESCRIPTION
## Information About the PR

Moved the config out of `package.json` to make it look more cleaner.

## Proposed Changes

- Removed key `lint-staged` from `package.json`
- Create a `.lintstagedrc.json` file and paste the settings there